### PR TITLE
新しいデータ配信形式への対応

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Synthetic Radar
+# 気象庁全国合成レーダーエコー強度
 10分毎の雨雲レーダーエコー図を作成します。
 
 ![](sample.gif)
@@ -10,10 +10,8 @@ python -m venv .venv
 ```
 
 ```
-#Unix
+#Linux
 source .venv/bin/activate
-#Windows
-source .venv/Scripts/activate
 ```
 
 # Installation
@@ -33,7 +31,7 @@ python src/main.py
  
 # Features
 - ### 機能
-   任意の日時および範囲の雨雲レーダー図を作成することができます。また、オプションで1日毎のgifやmp4を作成することができ、降雨域の時間発展をみることができます。また、標高を表示することで、より詳細に雨雲の発生域を捉えられます。
+   任意の日時および範囲の雨雲レーダー図を作成することができます。また、オプションで1日毎のgifやmp4を作成することができます。また、標高を表示することで、より詳細に雨雲の発生域を捉えられます。
    
 - ### 使用データ
    雨雲レーダーのデータは、気象庁1kmメッシュ全国合成レーダーエコー強度GPVのデータを用いています。[詳細な仕様はこちら](https://www.jmbsc.or.jp/jp/online/file/f-online30100.html)<br>

--- a/src/gpv/gpv_fetcher.py
+++ b/src/gpv/gpv_fetcher.py
@@ -20,14 +20,23 @@ def get_jma_gpv(utc_datetime: datetime) -> MaskedArray:
         target_datetime.hour,
         target_datetime.minute,
     )
-    url = f"http://database.rish.kyoto-u.ac.jp/arch/jmadata/data/jma-radar/synthetic/original/{year}/{month}/{day}/Z__C_RJTD_{year}{month}{day}{hour}{minute}00_RDR_JMAGPV__grib2.tar"
-    res_data = fetch_data(url)
+    base_url = f"http://database.rish.kyoto-u.ac.jp/arch/jmadata/data/jma-radar/synthetic/original/{year}/{month}/{day}"
+    if utc_datetime <= datetime(2024, 2, 29, 14, 0):
+        filename = f"Z__C_RJTD_{year}{month}{day}{hour}{minute}00_RDR_JMAGPV__grib2.tar"
+        is_tar = True
+        time_resolution = 10
+    else:
+        filename = f"Z__C_RJTD_{year}{month}{day}{hour}{minute}00_RDR_JMAGPV_Ggis1km_Prr05lv_ANAL_grib2.bin"
+        is_tar = False
+        time_resolution = 5
+    end_point = f"{base_url}/{filename}"
+    res_data = fetch_data(end_point)
     # Due to the nature of the library, data cannot be retrieved without writing to a file.
     with NamedTemporaryFile(mode="wb") as f:
         f.write(res_data)
         gpv_array: MaskedArray = load_jmara_grib2(
             file=f.name,
-            tar_flag=True,
-            tar_contentname=f"Z__C_RJTD_{year}{month}{day}{hour}{minute}00_RDR_JMAGPV_Ggis1km_Prr10lv_ANAL_grib2.bin",
+            tar_flag=is_tar,
+            tar_contentname=f"Z__C_RJTD_{year}{month}{day}{hour}{minute}00_RDR_JMAGPV_Ggis1km_Prr{str(time_resolution).zfill(2)}lv_ANAL_grib2.bin",
         )
     return gpv_array

--- a/src/main.py
+++ b/src/main.py
@@ -5,8 +5,8 @@ import pandas as pd
 from figure.plot import FigureFactory
 
 if __name__ == "__main__":
-    start_datetime = datetime(2023, 8, 16, 0, 0)
-    end_datetime = datetime(2023, 8, 16, 23, 50)
+    start_datetime = datetime(2024, 7, 20, 0, 0)
+    end_datetime = datetime(2024, 7, 20, 23, 50)
     jst_datetimes = pd.date_range(start_datetime, end_datetime, freq="10min")
     factory = FigureFactory(jst_datetimes)
     factory.make_continuous_figures()


### PR DESCRIPTION
2024年2月29日より気象庁の合成レーダーデータの配信形式が変更されたことに伴い、データ取得先のURL等が変更されたので、それに対応しました。